### PR TITLE
fix: last element not compared in this function

### DIFF
--- a/packages/comparison/shallow-array-equal/src/index.ts
+++ b/packages/comparison/shallow-array-equal/src/index.ts
@@ -2,7 +2,7 @@ export default (a: Array<any>, b: Array<any>) => {
   if (!Array.isArray(a) || !Array.isArray(b)) return false;
   if (a.length !== b.length) return false;
   const len = a.length;
-  for (let index = 0; index < len - 1; index++) {
+  for (let index = 0; index < len; index++) {
     if (a[index] !== b[index]) return false;
   }
 


### PR DESCRIPTION
test and found [1,3,5] equals [1,3,4] 